### PR TITLE
user/item rel tables and backend updates to handle rel data

### DIFF
--- a/backend/api/Cargo.lock
+++ b/backend/api/Cargo.lock
@@ -35,6 +35,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-files"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81bde9a79336aa51ebed236e91fc1a0528ff67cfdf4f68ca4c61ede9fd26fb5"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +274,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
+ "actix-files",
  "actix-web",
  "bcrypt",
  "chrono",
@@ -260,6 +284,12 @@ dependencies = [
  "serde_json",
  "sqlx",
 ]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "atoi"
@@ -849,6 +879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1040,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1821,6 +1867,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/backend/api/Cargo.toml
+++ b/backend/api/Cargo.toml
@@ -3,11 +3,15 @@ name = "api"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "api"
+path = "src/main.rs"
+
 
 [dependencies]
 actix-web = "4"
 actix-cors = "0.6.0-beta.4"
+actix-files = "0.6.0"
 log = "0.4.0"
 serde = {version = "1.0.137", features = ["derive"]}
 serde_json = "1.0"

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -1,20 +1,20 @@
 FROM rust:latest
 
-RUN USER=root cargo new --bin api
 WORKDIR /api
 
-COPY ./Cargo.lock ./Cargo.lock
+RUN echo "fn main() {}" > dummy.rs
 COPY ./Cargo.toml ./Cargo.toml
 
-RUN ls
+RUN sed -i 's#src/main.rs#dummy.rs#' Cargo.toml
 
-RUN cargo build --release & rm src/*.rs
+RUN cargo build --release
+
+RUN sed -i 's#dummy.rs#src/main.rs#' Cargo.toml
 
 COPY ./src ./src
 COPY ./migrations ./migrations
 COPY .env.docker .env
 
-RUN if [-f "./target/release/deps/api*"]; then rm ./target/release/deps/api*; fi;
-RUN cargo install --path .
+RUN cargo build --release
 
-CMD ["api"]
+CMD ["target/release/api"]

--- a/backend/api/README.html
+++ b/backend/api/README.html
@@ -1,0 +1,609 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>README.md</title>
+<meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+
+<style>
+/* https://github.com/microsoft/vscode/blob/master/extensions/markdown-language-features/media/markdown.css */
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+body {
+	font-family: var(--vscode-markdown-font-family, -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif);
+	font-size: var(--vscode-markdown-font-size, 14px);
+	padding: 0 26px;
+	line-height: var(--vscode-markdown-line-height, 22px);
+	word-wrap: break-word;
+}
+
+#code-csp-warning {
+	position: fixed;
+	top: 0;
+	right: 0;
+	color: white;
+	margin: 16px;
+	text-align: center;
+	font-size: 12px;
+	font-family: sans-serif;
+	background-color:#444444;
+	cursor: pointer;
+	padding: 6px;
+	box-shadow: 1px 1px 1px rgba(0,0,0,.25);
+}
+
+#code-csp-warning:hover {
+	text-decoration: none;
+	background-color:#007acc;
+	box-shadow: 2px 2px 2px rgba(0,0,0,.25);
+}
+
+body.scrollBeyondLastLine {
+	margin-bottom: calc(100vh - 22px);
+}
+
+body.showEditorSelection .code-line {
+	position: relative;
+}
+
+body.showEditorSelection .code-active-line:before,
+body.showEditorSelection .code-line:hover:before {
+	content: "";
+	display: block;
+	position: absolute;
+	top: 0;
+	left: -12px;
+	height: 100%;
+}
+
+body.showEditorSelection li.code-active-line:before,
+body.showEditorSelection li.code-line:hover:before {
+	left: -30px;
+}
+
+.vscode-light.showEditorSelection .code-active-line:before {
+	border-left: 3px solid rgba(0, 0, 0, 0.15);
+}
+
+.vscode-light.showEditorSelection .code-line:hover:before {
+	border-left: 3px solid rgba(0, 0, 0, 0.40);
+}
+
+.vscode-light.showEditorSelection .code-line .code-line:hover:before {
+	border-left: none;
+}
+
+.vscode-dark.showEditorSelection .code-active-line:before {
+	border-left: 3px solid rgba(255, 255, 255, 0.4);
+}
+
+.vscode-dark.showEditorSelection .code-line:hover:before {
+	border-left: 3px solid rgba(255, 255, 255, 0.60);
+}
+
+.vscode-dark.showEditorSelection .code-line .code-line:hover:before {
+	border-left: none;
+}
+
+.vscode-high-contrast.showEditorSelection .code-active-line:before {
+	border-left: 3px solid rgba(255, 160, 0, 0.7);
+}
+
+.vscode-high-contrast.showEditorSelection .code-line:hover:before {
+	border-left: 3px solid rgba(255, 160, 0, 1);
+}
+
+.vscode-high-contrast.showEditorSelection .code-line .code-line:hover:before {
+	border-left: none;
+}
+
+img {
+	max-width: 100%;
+	max-height: 100%;
+}
+
+a {
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
+a:focus,
+input:focus,
+select:focus,
+textarea:focus {
+	outline: 1px solid -webkit-focus-ring-color;
+	outline-offset: -1px;
+}
+
+hr {
+	border: 0;
+	height: 2px;
+	border-bottom: 2px solid;
+}
+
+h1 {
+	padding-bottom: 0.3em;
+	line-height: 1.2;
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
+}
+
+h1, h2, h3 {
+	font-weight: normal;
+}
+
+table {
+	border-collapse: collapse;
+}
+
+table > thead > tr > th {
+	text-align: left;
+	border-bottom: 1px solid;
+}
+
+table > thead > tr > th,
+table > thead > tr > td,
+table > tbody > tr > th,
+table > tbody > tr > td {
+	padding: 5px 10px;
+}
+
+table > tbody > tr + tr > td {
+	border-top: 1px solid;
+}
+
+blockquote {
+	margin: 0 7px 0 5px;
+	padding: 0 16px 0 10px;
+	border-left-width: 5px;
+	border-left-style: solid;
+}
+
+code {
+	font-family: Menlo, Monaco, Consolas, "Droid Sans Mono", "Courier New", monospace, "Droid Sans Fallback";
+	font-size: 1em;
+	line-height: 1.357em;
+}
+
+body.wordWrap pre {
+	white-space: pre-wrap;
+}
+
+pre:not(.hljs),
+pre.hljs code > div {
+	padding: 16px;
+	border-radius: 3px;
+	overflow: auto;
+}
+
+pre code {
+	color: var(--vscode-editor-foreground);
+	tab-size: 4;
+}
+
+/** Theming */
+
+.vscode-light pre {
+	background-color: rgba(220, 220, 220, 0.4);
+}
+
+.vscode-dark pre {
+	background-color: rgba(10, 10, 10, 0.4);
+}
+
+.vscode-high-contrast pre {
+	background-color: rgb(0, 0, 0);
+}
+
+.vscode-high-contrast h1 {
+	border-color: rgb(0, 0, 0);
+}
+
+.vscode-light table > thead > tr > th {
+	border-color: rgba(0, 0, 0, 0.69);
+}
+
+.vscode-dark table > thead > tr > th {
+	border-color: rgba(255, 255, 255, 0.69);
+}
+
+.vscode-light h1,
+.vscode-light hr,
+.vscode-light table > tbody > tr + tr > td {
+	border-color: rgba(0, 0, 0, 0.18);
+}
+
+.vscode-dark h1,
+.vscode-dark hr,
+.vscode-dark table > tbody > tr + tr > td {
+	border-color: rgba(255, 255, 255, 0.18);
+}
+
+</style>
+
+<style>
+/* Tomorrow Theme */
+/* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
+/* Original theme - https://github.com/chriskempson/tomorrow-theme */
+
+/* Tomorrow Comment */
+.hljs-comment,
+.hljs-quote {
+	color: #8e908c;
+}
+
+/* Tomorrow Red */
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-regexp,
+.hljs-deletion {
+	color: #c82829;
+}
+
+/* Tomorrow Orange */
+.hljs-number,
+.hljs-built_in,
+.hljs-builtin-name,
+.hljs-literal,
+.hljs-type,
+.hljs-params,
+.hljs-meta,
+.hljs-link {
+	color: #f5871f;
+}
+
+/* Tomorrow Yellow */
+.hljs-attribute {
+	color: #eab700;
+}
+
+/* Tomorrow Green */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
+	color: #718c00;
+}
+
+/* Tomorrow Blue */
+.hljs-title,
+.hljs-section {
+	color: #4271ae;
+}
+
+/* Tomorrow Purple */
+.hljs-keyword,
+.hljs-selector-tag {
+	color: #8959a8;
+}
+
+.hljs {
+	display: block;
+	overflow-x: auto;
+	color: #4d4d4c;
+	padding: 0.5em;
+}
+
+.hljs-emphasis {
+	font-style: italic;
+}
+
+.hljs-strong {
+	font-weight: bold;
+}
+</style>
+
+<style>
+/*
+ * Markdown PDF CSS
+ */
+
+ body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI", "Ubuntu", "Droid Sans", sans-serif, "Meiryo";
+	padding: 0 12px;
+}
+
+pre {
+	background-color: #f8f8f8;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	overflow-x: auto;
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+}
+
+pre:not(.hljs) {
+	padding: 23px;
+	line-height: 19px;
+}
+
+blockquote {
+	background: rgba(127, 127, 127, 0.1);
+	border-color: rgba(0, 122, 204, 0.5);
+}
+
+.emoji {
+	height: 1.4em;
+}
+
+code {
+	font-size: 14px;
+	line-height: 19px;
+}
+
+/* for inline code */
+:not(pre):not(.hljs) > code {
+	color: #C9AE75; /* Change the old color so it seems less like an error */
+	font-size: inherit;
+}
+
+/* Page Break : use <div class="page"/> to insert page break
+-------------------------------------------------------- */
+.page {
+	page-break-after: always;
+}
+
+</style>
+
+<script src="https://unpkg.com/mermaid/dist/mermaid.min.js"></script>
+</head>
+<body>
+  <script>
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: document.body.classList.contains('vscode-dark') || document.body.classList.contains('vscode-high-contrast')
+          ? 'dark'
+          : 'default'
+    });
+  </script>
+<h1 id="build-backend">Build Backend:</h1>
+<blockquote>
+<p>Requires .env file in base directory</p>
+<p><a href="../example.env">Example .env file</a></p>
+<p>In backend directory:</p>
+<pre class="hljs"><code><div>cargo run
+</div></code></pre>
+</blockquote>
+<h1 id="api-routes">API Routes:</h1>
+<h2 id="get-apistatus">GET /api/status</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>No Request Parameters</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+{
+    &quot;api_active&quot;: true,
+    &quot;db_active&quot;: true
+}
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="get-apiuser">GET /api/user</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>No Request Parameters</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+</blockquote>
+<blockquote>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+[
+    {
+        &quot;id&quot;: 1,
+        &quot;username&quot;: &quot;testuser1&quot;,
+        &quot;password&quot;: &quot;testpassword1&quot;
+    },
+    {
+        &quot;id&quot;: 2,
+        &quot;username&quot;: &quot;testuser2&quot;,
+        &quot;password&quot;: &quot;testpassword2&quot;
+    }
+]
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="post-apiuser">POST /api/user</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>{
+    &quot;username&quot;: &quot;db_createduser1&quot;,
+    &quot;password&quot;: &quot;db_password1&quot;
+}
+</div></code></pre>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 201
+
+{
+    &quot;id&quot;: 3,
+    &quot;username&quot;: &quot;db_createduser1&quot;,
+    &quot;password&quot;: &quot;db_password1&quot;
+}
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="get-apiuserid">GET /api/user/{id}</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>id: integer</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+{
+    &quot;id&quot;: 3,
+    &quot;username&quot;: &quot;db_createduser1&quot;,
+    &quot;password&quot;: &quot;db_password1&quot;
+}
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="delete-apiuserid">DELETE /api/user/{id}</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>id: integer</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 204
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="get-apiuseriditem">GET /api/user/{id}/item</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>id: integer</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+[
+    {
+        &quot;id&quot;:9,
+        &quot;name&quot;:&quot;testitem1&quot;,
+        &quot;is_lent_item&quot;:true,
+        &quot;img_uri&quot;:&quot;img1.jpg&quot;,
+        &quot;lend_start&quot;:&quot;2022-05-25T05:49:22.473895+00:00&quot;,
+        &quot;lend_end&quot;:&quot;2022-05-25T05:49:22.473943+00:00&quot;,
+        &quot;owner_id&quot;:1,
+        &quot;borrower_id&quot;:2
+    }
+]
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="get-apiitem">GET /api/item</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>No Request Parameters</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+</blockquote>
+<blockquote>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+[
+    {
+        &quot;id&quot;:1,
+        &quot;name&quot;:&quot;testitem1&quot;,
+        &quot;is_lent_item&quot;:true,
+        &quot;img_uri&quot;:&quot;img1.jpg&quot;,
+        &quot;lend_start&quot;:&quot;2022-05-16T18:59:01.139024-07:00&quot;,
+        &quot;lend_end&quot;:&quot;2022-05-16T18:59:01.139032-07:00&quot;
+    }
+]
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="post-apiitem">POST /api/item</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>{
+        &quot;id&quot;:1,
+        &quot;name&quot;:&quot;testitem1&quot;,
+        &quot;is_lent_item&quot;:true,
+        &quot;img_uri&quot;:&quot;img1.jpg&quot;,
+        &quot;lend_start&quot;:&quot;2022-05-16T18:59:01.139024-07:00&quot;,
+        &quot;lend_end&quot;:&quot;2022-05-16T18:59:01.139032-07:00&quot;
+}
+</div></code></pre>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 201
+
+{
+        &quot;id&quot;:1,
+        &quot;name&quot;:&quot;testitem1&quot;,
+        &quot;is_lent_item&quot;:true,
+        &quot;img_uri&quot;:&quot;img1.jpg&quot;,
+        &quot;lend_start&quot;:&quot;2022-05-16T18:59:01.139024-07:00&quot;,
+        &quot;lend_end&quot;:&quot;2022-05-16T18:59:01.139032-07:00&quot;
+}
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="get-apiitemid">GET /api/item/{id}</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>id: integer</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+{
+        &quot;id&quot;:1,
+        &quot;name&quot;:&quot;testitem1&quot;,
+        &quot;is_lent_item&quot;:true,
+        &quot;img_uri&quot;:&quot;img1.jpg&quot;,
+        &quot;lend_start&quot;:&quot;2022-05-16T18:59:01.139024-07:00&quot;,
+        &quot;lend_end&quot;:&quot;2022-05-16T18:59:01.139032-07:00&quot;
+}
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="delete-apiitemid">DELETE /api/item/{id}</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<p>id: integer</p>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 204
+</div></code></pre>
+</blockquote>
+</blockquote>
+<h2 id="post-apiauth">POST /api/auth</h2>
+<blockquote>
+<h3 id="request-example">Request Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>{
+    &quot;username&quot;: &quot;db_createduser1&quot;,
+    &quot;password&quot;: &quot;db_password1&quot;
+}
+</div></code></pre>
+</blockquote>
+<h3 id="response-example">Response Example:</h3>
+<blockquote>
+<pre class="hljs"><code><div>Status Code: 200
+
+{
+    &quot;id&quot;: 3,
+    &quot;username&quot;: &quot;db_createduser1&quot;,
+    &quot;password&quot;: &quot;db_password1&quot;
+}
+</div></code></pre>
+</blockquote>
+</blockquote>
+
+</body>
+</html>

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -88,6 +88,27 @@
 > > Status Code: 204
 > > ```
 
+## GET /api/user/{id}/item
+> ### Request Example:
+> > id: integer
+> ### Response Example:
+> > ```
+> > Status Code: 200
+> >
+> > [
+> >     {
+> >         "id":9,
+> >         "name":"testitem1",
+> >         "is_lent_item":true,
+> >         "img_uri":"img1.jpg",
+> >         "lend_start":"2022-05-25T05:49:22.473895+00:00",
+> >         "lend_end":"2022-05-25T05:49:22.473943+00:00",
+> >         "owner_id":1,
+> >         "borrower_id":2
+> >     }
+> > ]
+> > ```
+
 
 ## GET /api/item
 > ### Request Example:

--- a/backend/api/migrations/20220525021026_rel_tables.sql
+++ b/backend/api/migrations/20220525021026_rel_tables.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS user_items (
+    item_id INT PRIMARY KEY NOT NULL,
+    owner_id INT NOT NULL,
+    borrower_id INT,
+    CONSTRAINT item 
+        FOREIGN KEY(item_id) 
+        REFERENCES items(id),
+    CONSTRAINT own
+        FOREIGN KEY(owner_id) 
+        REFERENCES users(id),
+    CONSTRAINT borrow
+        FOREIGN KEY(borrower_id)
+        REFERENCES users(id)
+);

--- a/backend/api/src/api/mod.rs
+++ b/backend/api/src/api/mod.rs
@@ -3,6 +3,7 @@ pub mod item;
 pub mod auth;
 
 use actix_web::{web, get, Scope, HttpResponse, Responder};
+use actix_files::NamedFile;
 use serde::{Serialize, Deserialize};
 use crate::logger;
 use crate::SessionData;
@@ -26,6 +27,7 @@ struct HttpError {
 pub fn config() -> Scope {
     web::scope(PREFIX)
         .service(status)
+        .service(docs)
         .service(api::user::config())
         .service(api::item::config())
         .service(api::auth::config())
@@ -34,6 +36,11 @@ pub fn config() -> Scope {
 // helper to log api routes reached
 pub fn log_api(method:&str, route:&str) {
     logger::route(method, PREFIX, route);
+}
+
+#[get("")]
+async fn docs() -> impl Responder {
+    NamedFile::open_async("README.md").await
 }
 
 #[get("/status")] // api base page

--- a/backend/api/src/api/mod.rs
+++ b/backend/api/src/api/mod.rs
@@ -40,7 +40,7 @@ pub fn log_api(method:&str, route:&str) {
 
 #[get("")]
 async fn docs() -> impl Responder {
-    NamedFile::open_async("README.md").await
+    NamedFile::open("./README.html")
 }
 
 #[get("/status")] // api base page

--- a/backend/api/src/api/user.rs
+++ b/backend/api/src/api/user.rs
@@ -14,6 +14,7 @@ pub fn config() -> Scope {
     .service(create_user)
     .service(delete_user_by_id)
     .service(user_by_id)
+    .service(get_user_items)
 }
 
 pub fn log_user(method:&str, route:&str) {
@@ -79,6 +80,23 @@ async fn delete_user_by_id(data: web::Data<SessionData>, id: web::Path<String>) 
         HttpResponse::NoContent().finish()
     } else {
         HttpResponse::NotFound().json(HttpError {
+            status_code: 404,
+            message: "user not found".to_string()
+        })
+    }
+}
+
+
+#[get("/{id}/item")]
+async fn get_user_items(data: web::Data<SessionData>, id: web::Path<String>) -> impl Responder {
+    let id_int = id.into_inner();
+    log_user("GET", &format!("/{}", id_int));
+    match User::from_db(&data.db, id_int).await {
+        Some(user) => match user.get_items(&data.db).await {
+            Some(items) => HttpResponse::Ok().json(items),
+            None => HttpResponse::Ok().finish()
+        },
+        None => HttpResponse::NotFound().json(HttpError {
             status_code: 404,
             message: "user not found".to_string()
         })

--- a/backend/api/src/db.rs
+++ b/backend/api/src/db.rs
@@ -103,7 +103,7 @@ impl Db {
     pub async fn get_items(&self) -> Option<Vec<Item>> {
         match &self.pool {
             Some(pool) => {
-                match sqlx::query_as::<_, Item>("SELECT * FROM items").fetch_all(&*pool).await {
+                match sqlx::query_as::<_, Item>("SELECT * FROM items i JOIN user_items ui ON ui.item_id = i.id").fetch_all(&*pool).await {
                     Ok(rows) => Some(rows),
                     Err(err) => {
                         warn!("Database query error: {}", err);

--- a/backend/api/src/models/item.rs
+++ b/backend/api/src/models/item.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Local};
-use sqlx::FromRow;
+use sqlx::{FromRow, Row};
 use serde::{Serialize, Deserialize};
 use crate::db::Db;
 
@@ -11,29 +11,54 @@ pub struct Item {
     is_lent_item: bool,
     img_uri: String,
     lend_start: DateTime<Local>,
-    lend_end: DateTime<Local>
+    lend_end: DateTime<Local>,
+    owner_id: Option<i32>,
+    borrower_id: Option<i32>
 }
 
 impl Item {
-    pub fn new(id:i32, name:String, is_lent_item:bool, img_uri:String, lend_start:DateTime<Local>, lend_end:DateTime<Local>) -> Self {
+    pub fn new(id:i32, name:String, is_lent_item:bool, img_uri:String, lend_start:DateTime<Local>, lend_end:DateTime<Local>, owner: Option<i32>, borrower: Option<i32>) -> Self {
         Self {
             id: Some(id),
             name: name,
             is_lent_item: is_lent_item,
             img_uri: img_uri,
             lend_start: lend_start,
-            lend_end: lend_end
+            lend_end: lend_end,
+            owner_id: owner,
+            borrower_id: borrower
         }
     }
 
     pub async fn to_db(&self, db: &Db) {
-        let q = format!("INSERT INTO items (name, is_lent_item, img_uri, lend_start, lend_end) VALUES ('{}', {}, '{}', '{}', '{}');",
+        let q = format!("INSERT INTO items (name, is_lent_item, img_uri, lend_start, lend_end) VALUES ('{}', {}, '{}', '{}', '{}') RETURNING id;",
         self.name, self.is_lent_item, self.img_uri, self.lend_start.to_rfc3339(), self.lend_end.to_rfc3339());
         match &db.pool {
             Some(pool) => {
                 match sqlx::query(&q)
-                .execute(&*pool).await {
-                    Ok(_) => info!("Item created."),
+                .fetch_one(&*pool).await {
+                    Ok(row) => {
+                        info!("Item created.");
+                        let item_id:i32 = row.get("id");
+                        match (self.owner_id, self.borrower_id) {
+                            (Some(o), Some(b)) => {
+                                match sqlx::query(&format!("INSERT INTO user_items VALUES ({}, {}, {})", item_id, o, b))
+                                .execute(&*pool).await {
+                                    Ok(_) => info!("user_item record created."),
+                                    Err(e) => warn!("user item creation error: {}", e)
+                                }
+                            },
+                            (Some(o), None) => {
+                                match sqlx::query(&format!("INSERT INTO user_items (item_id, owner_id) VALUES ({}, {})", item_id, o))
+                                .execute(&*pool).await {
+                                    Ok(_) => info!("user_item record created."),
+                                    Err(e) => warn!("user item creation error: {}", e)
+                                }
+                            },
+                            (_, _) => {}
+                        }
+                        
+                    }
                     Err(e) => warn!("Item creation error: {}",e)
                 }
             }
@@ -62,6 +87,6 @@ impl Item {
 }
 
 pub fn test_items() -> [Item; 2] {
-    [Item::new(1, "testitem1".to_string(), true, "img1.jpg".to_string(), Local::now(), Local::now()),
-    Item::new(2, "testitem2".to_string(), false, "img2.jpg".to_string(), Local::now(), Local::now())]
+    [Item::new(1, "testitem1".to_string(), true, "img1.jpg".to_string(), Local::now(), Local::now(), Some(1), Some(2)),
+    Item::new(2, "testitem2".to_string(), false, "img2.jpg".to_string(), Local::now(), Local::now(), Some(2), Some(1))]
 }


### PR DESCRIPTION
Built off previous PRS.
- add rel table for users & items
- update items model to contain owner/borrow ids
- update users & items to have optional id fields
- GET user/{id}/item now shoes all items owned by user (change to user/{id}/owns?)
- updated API documentation for new endpoint
- added API documentation html to GET /api
- FINALLY cached dependencies in docker builds